### PR TITLE
Release v1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shell-words"
-version = "0.1.0"
+version = "1.0.0"
 authors = ["Tomasz Miąsko <tomasz.miasko@gmail.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/tmiasko/shell-words"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Process command line according to parsing rules of Unix shell.
 Add this to Cargo.toml:
 ```toml
 [dependencies]
-shell-words = "0.1.0"
+shell-words = "1.0.0"
 ```
 
 Add this to your crate:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # shell-words
 
+[![unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/)
+
 Process command line according to parsing rules of Unix shell.
 
 ## Usage

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@
 //!
 //! [posix-shell]: http://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html
 
+#![forbid(unsafe_code)]
+
 use std::borrow::Cow;
 use std::error;
 use std::fmt;


### PR DESCRIPTION
This is intended to help potential users of this library assess the API
stability and general maturity of this library.

v1.0.0 is a commitment that the API will not change in a backwards
incompatible way before v2.0.0.  The API is stable and has been since the
crate was made available.  In fact the implementation hasn't had to change
in 2 years.  It is time for v1, and the API commitment that comes with it.