### PR TITLE
Fix incorrect parsing for | and > delimiters

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -378,6 +378,11 @@ mod tests {
     }
 
     #[test]
+    fn split_redirect() {
+        split_ok(&[("foo -b|bar s", &["foo", "-b", "|", "bar", "s"])]);
+    }
+
+    #[test]
     fn split_initial_whitespace_is_removed() {
         split_ok(&[
             ("     a", &["a"]),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,7 +171,15 @@ pub fn split(s: &str) -> Result<Vec<String>, ParseError> {
                     Delimiter
                 }
                 Some(c) => {
-                    word.push(c);
+                    match c {
+                        '|' | '>' => {
+                            words.push(mem::replace(&mut word, String::new()));
+                            words.push(String::from(c));
+                        }
+                        c => {
+                            word.push(c);
+                        }
+                    }
                     Unquoted
                 }
             },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,7 +172,7 @@ pub fn split(s: &str) -> Result<Vec<String>, ParseError> {
                 }
                 Some(c) => {
                     match c {
-                        '|' | '>' => {
+                        '|' | '>' | ';' => {
                             words.push(mem::replace(&mut word, String::new()));
                             words.push(String::from(c));
                         }


### PR DESCRIPTION
https://github.com/tmiasko/shell-words/issues/12#issue-1245745603