### PR TITLE
Use the correct tilde when escaping

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,7 +258,7 @@ fn escape_style(s: &str) -> EscapeStyle {
                 special = true;
             }
             '|' | '&' | ';' | '<' | '>' | '(' | ')' | '$' | '`' | '\\' | '"' | ' ' | '\t' | '*'
-            | '?' | '[' | '#' | '˜' | '=' | '%' => {
+            | '?' | '[' | '#' | '~' | '=' | '%' => {
                 special = true;
             }
             _ => continue,
@@ -479,6 +479,7 @@ mod tests {
         assert_eq!(quote("abc"), "abc");
         assert_eq!(quote("a \n  b"), "'a \n  b'");
         assert_eq!(quote("X'\nY"), "'X'\\''\nY'");
+        assert_eq!(quote("~root"), "'~root'");
     }
 
     #[test]


### PR DESCRIPTION
Replace `˜` U+02DC SMALL TILDE (from the Spacing Modifier Letters block) with `~` U+007E TILDE (from the Basic Latin block).

I assume your keyboard layout entered the wrong character at some point, and `˜`/`~` look similar enough...